### PR TITLE
Fix Deprecation warning for Python 3.7+

### DIFF
--- a/betterforms/forms.py
+++ b/betterforms/forms.py
@@ -69,7 +69,7 @@ def flatten(elements):
     iterable of strings.
     """
     for element in elements:
-        if isinstance(element, collections.Iterable) and not isinstance(element, six.string_types):
+                if isinstance(element, collections.abc.Iterable) and not isinstance(element, six.string_types):
             for sub_element in flatten(element):
                 yield sub_element
         else:


### PR DESCRIPTION
I was getting the following deprecation warning in Python 3.7:

```
betterforms/forms.py:72: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  if isinstance(element, collections.Iterable) and not isinstance(element, six.string_types):
```

This seems to be the fix. 


As an aside is there any interest in some PRs gutting Python2 and Django<2 support?  