### PR TITLE
Fix Import Error tied to original version

### DIFF
--- a/betterforms/__init__.py
+++ b/betterforms/__init__.py
@@ -1,1 +1,1 @@
-__version__ = __import__('pkg_resources').get_distribution('django-betterforms').version
+__version__ = __import__('pkg_resources').get_distribution('django-betterforms-jpic').version


### PR DESCRIPTION
When using this with django 3.2 after `pip install django-betterforms-jpic`

The following error occurs:
```
Traceback (most recent call last):
  File "C:\Users\dbutler\AppData\Local\Programs\Python\Python39\lib\threading.py", line 954, in _bootstrap_inner
    self.run()
  File "C:\code\mb-receipts\venv\lib\site-packages\sentry_sdk\integrations\threading.py", line 69, in run
    reraise(*_capture_exception())
  File "C:\code\mb-receipts\venv\lib\site-packages\sentry_sdk\_compat.py", line 54, in reraise
    raise value
  File "C:\code\mb-receipts\venv\lib\site-packages\sentry_sdk\integrations\threading.py", line 67, in run
    return old_run_func(self, *a, **kw)
  File "C:\Users\dbutler\AppData\Local\Programs\Python\Python39\lib\threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)
  File "C:\code\mb-receipts\venv\lib\site-packages\django\utils\autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "C:\code\mb-receipts\venv\lib\site-packages\django\core\management\commands\runserver.py", line 110, in inner_run
    autoreload.raise_last_exception()
  File "C:\code\mb-receipts\venv\lib\site-packages\django\utils\autoreload.py", line 87, in raise_last_exception
    raise _exception[1]
  File "C:\code\mb-receipts\venv\lib\site-packages\django\core\management\__init__.py", line 375, in execute
    autoreload.check_errors(django.setup)()
  File "C:\code\mb-receipts\venv\lib\site-packages\django\utils\autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "C:\code\mb-receipts\venv\lib\site-packages\django\__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "C:\code\mb-receipts\venv\lib\site-packages\django\apps\registry.py", line 91, in populate
    app_config = AppConfig.create(entry)
  File "C:\code\mb-receipts\venv\lib\site-packages\django\apps\config.py", line 224, in create
    import_module(entry)
  File "C:\Users\dbutler\AppData\Local\Programs\Python\Python39\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "C:\code\mb-receipts\venv\lib\site-packages\betterforms\__init__.py", line 1, in <module>
    __version__ = __import__('pkg_resources').get_distribution('django-betterforms').version
  File "C:\code\mb-receipts\venv\lib\site-packages\pkg_resources\__init__.py", line 465, in get_distribution
    dist = get_provider(dist)
  File "C:\code\mb-receipts\venv\lib\site-packages\pkg_resources\__init__.py", line 341, in get_provider
    return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
  File "C:\code\mb-receipts\venv\lib\site-packages\pkg_resources\__init__.py", line 884, in require
    needed = self.resolve(parse_requirements(requirements))
  File "C:\code\mb-receipts\venv\lib\site-packages\pkg_resources\__init__.py", line 770, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'django-betterforms' distribution was not found and is required by the application
```